### PR TITLE
fix: Fix crashes and logic issues when initializing message adapter and handling conversation joins

### DIFF
--- a/app/src/main/java/com/demo/messageapp/repository/ConversationRepository.kt
+++ b/app/src/main/java/com/demo/messageapp/repository/ConversationRepository.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModelProvider
 import com.demo.messageapp.model.Conversation
 import com.demo.messageapp.viewmodel.ConversationViewModel
 import com.demo.messageapp.viewmodel.UserViewModel
+import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.FirebaseFirestore
 
 class ConversationRepository {
@@ -13,6 +14,14 @@ class ConversationRepository {
     fun createConversation(participantIds: List<String>, conversationName: String, currentUserId: String, callback: (Boolean, String?, String?) -> Unit) {
         val conversationRef = db.collection("conversations").document()
         val conversationId = conversationRef.id
+
+        fun addConversationIdtoParticipants() {
+            val userRef = db.collection("users")
+            for(participantId in participantIds) {
+                userRef.document(participantId)
+                    .update("joinedConversations", FieldValue.arrayUnion(conversationId))
+            }
+        }
 
         if (conversationName.isNotEmpty()) {
             // Nếu có tên cuộc trò chuyện, tạo và lưu cuộc trò chuyện ngay lập tức
@@ -26,6 +35,7 @@ class ConversationRepository {
 
             conversationRef.set(conversation)
                 .addOnSuccessListener { _ ->
+                    addConversationIdtoParticipants()
                     callback(true, null, conversationId)
                 }
                 .addOnFailureListener { e ->
@@ -50,6 +60,7 @@ class ConversationRepository {
 
                         conversationRef.set(conversation)
                             .addOnSuccessListener { _ ->
+                                addConversationIdtoParticipants()
                                 callback(true, null, conversationId)
                             }
                             .addOnFailureListener { e ->

--- a/app/src/main/java/com/demo/messageapp/repository/MessageRepository.kt
+++ b/app/src/main/java/com/demo/messageapp/repository/MessageRepository.kt
@@ -125,32 +125,33 @@ class MessageRepository {
             .collection("messages")
             .orderBy("timestamp", Query.Direction.ASCENDING)
             .addSnapshotListener { snapshots, e ->
-                if (e != null || snapshots == null) {
-                    callback(false, "Snapshot is null", null)
+                if (e != null) {
+                    callback(false, "Error fetching messages: ${e.message}", null)
                     return@addSnapshotListener
                 }
 
                 val messageList = mutableListOf<Message>()
-                for (doc in snapshots.documents) {
-                    val id = doc.id
-                    val senderId = doc.getString("senderId") ?: ""
-                    val isSentByMe = doc.getBoolean("isSentByMe") ?: false
-                    val content = doc.getString("content") ?: ""
-                    val timestamp = doc.getLong("timestamp") ?: 0
-                    val type = doc.getString("type") ?: ""
-                    val deleted = doc.getBoolean("deleted") ?: false
+                if (snapshots != null && !snapshots.isEmpty) {
+                    for (doc in snapshots.documents) {
+                        val id = doc.id
+                        val senderId = doc.getString("senderId") ?: ""
+                        val isSentByMe = doc.getBoolean("isSentByMe") ?: false
+                        val content = doc.getString("content") ?: ""
+                        val timestamp = doc.getLong("timestamp") ?: 0
+                        val type = doc.getString("type") ?: ""
+                        val deleted = doc.getBoolean("deleted") ?: false
 
-                    val message = Message(
-                        id = id,
-                        senderId = senderId,
-                        isSentByMe = isSentByMe,
-                        content = content,
-                        timestamp = timestamp,
-                        type = type,
-                        deleted = deleted
-                    )
-
-                    messageList.add(message)
+                        val message = Message(
+                            id = id,
+                            senderId = senderId,
+                            isSentByMe = isSentByMe,
+                            content = content,
+                            timestamp = timestamp,
+                            type = type,
+                            deleted = deleted
+                        )
+                        messageList.add(message)
+                    }
                 }
                 callback(true, null, messageList)
             }

--- a/app/src/main/java/com/demo/messageapp/viewmodel/ConversationViewModel.kt
+++ b/app/src/main/java/com/demo/messageapp/viewmodel/ConversationViewModel.kt
@@ -32,14 +32,20 @@ class ConversationViewModel : ViewModel() {
     }
     fun getConversationTwoUID(uid1: String, uid2: String) {
         repository.getConversationList(uid2) {success, message, conversationList ->
-            val conversation = conversationList!!.firstOrNull { conversation ->
-                val participantIds = conversation.participantIds ?: emptyList()
+            if (conversationList != null) {
+                if(conversationList.isNotEmpty()) {
+                    val conversation = conversationList.firstOrNull { conversation ->
+                        val participantIds = conversation.participantIds ?: emptyList()
 
-                participantIds.size == 2 &&
-                        participantIds.contains(uid1) &&
-                        participantIds.contains(uid2)
+                        participantIds.size == 2 &&
+                                participantIds.contains(uid1) &&
+                                participantIds.contains(uid2)
+                    }
+                    getConversationTwoUidResult.value = GetConversationTwoUIDResult(success, message, conversation?.id)
+                } else {
+                    getConversationTwoUidResult.value = GetConversationTwoUIDResult(success, message, "")
+                }
             }
-            getConversationTwoUidResult.value = GetConversationTwoUIDResult(success, message, conversation?.id)
         }
     }
     fun resetConversationTwoUidResult() {


### PR DESCRIPTION
1. Crash when initializing message adapter without subcollection:
- Fixed a crash that occurred when attempting to add the message adapter before the corresponding Firestore subcollection was initialized.
- Now checks and ensures the subcollection is ready before proceeding.

2. Missing conversation ID when participants join:
- Fixed an issue where a newly created conversation ID was not added to participants' joined conversations.
- Also added handling for the case when no conversation exists between two UIDs, ensuring an empty result is returned instead of nothing.